### PR TITLE
Added CMake build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.20)
+project(rocket-game
+    LANGUAGES CXX
+)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED)
+
+# Fetch source of SDL2
+include(FetchContent)
+set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
+FetchContent_Declare(sdl2
+    GIT_REPOSITORY https://github.com/libsdl-org/SDL
+    GIT_TAG release-2.0.22
+)
+
+FetchContent_GetProperties(sdl2)
+if(NOT sdl2_POPULATED)
+FetchContent_Populate(sdl2)
+    add_subdirectory(${sdl2_SOURCE_DIR} ${sdl2_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
+
+# for SDL2 header files
+include_directories(${sdl2_SOURCE_DIR}/include)
+
+#Game engine
+add_library(EngineLib game_lib.cpp)
+
+#Main game
+add_executable(rocket-game rocket_game.cpp)
+target_link_libraries(rocket-game PRIVATE EngineLib SDL2::SDL2)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-To install the lib SDL2:
-	sudo apt-get install libsdl2-2.0
-	sudo apt install libsdl2-dev
-	
-To compile the game, type:
-	g++ -o main main.cpp -lSDL
+## Build
+- Install "CMake" and "Make"
+	* sudo apt install make
+	* sudo snap install cmake (snap has newer version)
+- ```mkdir build```
+- ```cd build```
+- ```cmake ..```
+- ```make```
+- You will get "rocket-game" executable. Enjoy!
+
+May take some time for first build because of building SDL2. Further builds are fast

--- a/game_lib.h
+++ b/game_lib.h
@@ -1,7 +1,7 @@
 #ifndef __GAME_LIB_OBJ__
 #define __GAME_LIB_OBJ__
 
-#include <SDL2/SDL.h>
+#include "SDL.h"
 #include <functional>
 #include <cinttypes>
 #include <chrono>

--- a/rocket_game.h
+++ b/rocket_game.h
@@ -1,7 +1,7 @@
 #ifndef __ROCKET_GAME__
 #define __ROCKET_GAME__
 
-#include <SDL2/SDL.h>
+#include "SDL.h"
 #include <iostream>
 #include <cstdlib>
 #include <ctime>


### PR DESCRIPTION
CMake allows to use any version of SDL2 and not to install it to the system globally, not to compile files, that was not changed by using building of libraries and etc. Anyone can just clone repo and build project by two commands.

- Changed two include strings (<SDL2/SDL.h> -> "SDL.h")
- Added CMakeLists.txt
- Changed README.md to describe building with CMake
- Added "build/" to .gitignore
Building is working ok
![1](https://user-images.githubusercontent.com/39347109/175167110-38f6e49b-8c0a-49d1-a8db-848d5b5e6138.png)

P.S. I set C++ standard as 17 in CMakeLists.txt - change it to your standard